### PR TITLE
Graphic Upgrades and addExposed

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: FaultTree
 Type: Package
 Title: Fault Trees for Risk and Reliability Analysis
-Version: 0.0.9
-Date: 2016-6-29
+Version: 0.0.10
+Date: 2016-8-10
 Author: Jacob T. Ormerod
 Maintainer: Jacob T. Ormerod <jake@openreliability.org>
 Description: A package for constructing,calculating and displaying fault trees.

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,6 +1,7 @@
 export(addActive,
 addDemand,
 addDuplicate,
+addExposed,
 addLatent,
 addLogic,
 addProbability,

--- a/R/addDemand.R
+++ b/R/addDemand.R
@@ -17,7 +17,7 @@
 addDemand<-function(DF, at, mttf, tag="", name="", name2="", description="")  {
 	if(!ftree.test(DF)) stop("first argument must be a fault tree")
 
- 	tp=4
+ 	tp=3
 	parent<-which(DF$ID== at)
 	if(length(parent)==0) {stop("connection reference not valid")}
 	thisID<-max(DF$ID)+1
@@ -28,18 +28,28 @@ addDemand<-function(DF, at, mttf, tag="", name="", name2="", description="")  {
 	}
 
 ## There is no need to limit connections to OR gates for calculation reasons
-## Since AND gates are calculated in binary fashion, these too should not require a connection limit
+## Since AND gates are calculated in binary fashion, these too should not
+## require a connection limit, but practicality suggests 3 is a good limit.
 ## All specialty gates must be limited to binary feeds only
 
-##	if(DF$Type[parent]>11 && length(which(DF$Parent==at))>1) {
-##		stop("connection slot not available")
-#3	}
+	if(DF$Type[parent]==11 && length(which(DF$Parent==at))>2) {
+		warning("More than 3 connections to AND gate.")
+	}
+	
+	if(any(DF$Type==5)) {
+		stop("repairable system event event called for in non-repairable model")
+	}
+
+		if(tag!="")  {
+		if (length(which(DF$Tag == tag) != 0)) {
+		stop("tag is not unique")
+		}
+	}
 
 	condition=0
 	if(DF$Type[parent]>11 )  {
 		if( length(which(DF$CParent==at))==0)  {
-			condition=1
-			warning("Basic Event with no probability set as a condition")
+			stop("Basic Event with no probability set as a condition")
 		}else{
 			if(length(which(DF$CParent==at))>1)  {
 				stop("connection slot not available")

--- a/R/addExposed.R
+++ b/R/addExposed.R
@@ -1,0 +1,106 @@
+ addExposed<-	function (DF, at, mttf, exposure=NULL, dist="exponential", p2=NULL,
+		display_under=NULL, tag="", name="",name2="", description="")  {
+
+	if (!ftree.test(DF))  stop("first argument must be a fault tree")
+
+	tp <-5
+	parent <- which(DF$ID == at)
+	if (length(parent) == 0) {
+	stop("connection reference not valid")
+	}
+	thisID <- max(DF$ID) + 1
+	if (DF$Type[parent] < 10) {
+	stop("non-gate connection requested")
+	}
+	if (!DF$MOE[parent] == 0) {
+	stop("connection cannot be made to duplicate nor source of duplication")
+	}
+	
+	if(any(DF$Type<4)|| any(DF$Type>12)) {
+		stop("non-repairable system event called for in repairable model")
+	}
+	
+	if(tag!="")  {
+		if (length(which(DF$Tag == tag) != 0)) {
+		stop("tag is not unique")
+		}
+	}
+	## There is no need to limit connections to OR gates for calculation reasons
+	## Since AND gates are calculated in binary fashion, these too should not
+	## require a connection limit, practicality suggests 3 is a good limit.
+	## All specialty gates must be limited to binary feeds only
+
+	if(DF$Type[parent]==11 && length(which(DF$Parent==at))>2) {
+		warning("More than 3 connections to AND gate.")
+	}
+	condition = 0
+	if (DF$Type[parent] > 11) {
+		if (length(which(DF$CParent == at)) == 0) {
+			condition = 1
+		}else {
+			if (length(which(DF$CParent == at)) > 1) {
+			stop("connection slot not available")
+			}
+		}
+	}
+
+
+	if (is.null(mttf)) {
+	stop("exposed component must have mttf")
+	}
+
+	if (is.null(exposure)) {
+		stop("exposed component must have exposure entry")
+	}
+
+	if (is.character(exposure)) {
+		if (exists("exposure")) {
+		Tao <- eval((parse(text = exposure)))
+		}else {
+			stop("exposure object does not exist")
+		}
+	}else {
+		Tao = exposure
+	}
+
+	if(dist=="exponential")  {
+		pf<-1 - exp(-(1/mttf) * Tao)
+	}else {
+		stop("only exponential implemented at this time")
+	}
+
+	gp<-at
+	if(length(display_under)!=0)  {
+		if(DF$Type[parent]!=10) {stop("Component stacking only permitted under OR gate")}
+		if(DF$CParent[display_under]!=at) {stop("Must stack at component under same parent")}
+		if(length(which(DF$GParent==display_under))>0 )  {
+			stop("display under connection not available")
+		}else{
+			gp<-display_under
+		}
+	}
+
+	Dfrow <- data.frame(
+		ID = thisID,
+		GParent = gp,
+		CParent = at,
+		Level = DF$Level[parent] + 1,
+		Type = tp,
+		CFR = 1/mttf,
+		PBF = pf,
+		CRT = -1,
+		MOE = 0,
+		PHF_PZ = -1,
+		Condition = condition,
+		Repairable = 0,
+		Interval = Tao,
+		Tag_Obj = tag,
+		Name = name,
+		Name2 = name2,
+		Description = description,
+		Unused1 = "",
+		Unused2 = "")
+
+	DF <- rbind(DF, Dfrow)
+	DF
+	}

--- a/R/addLatent.R
+++ b/R/addLatent.R
@@ -14,7 +14,7 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-addLatent<-function(DF, at, mttf, mttr=NULL, pzero="repair", inspect=NULL, tag="", name="",name2="", description="")  {
+addLatent<-function(DF, at, mttf, mttr=NULL, pzero="repair", inspect=NULL, display_under=NULL, tag="", name="",name2="", description="")  {
 	if(!ftree.test(DF)) stop("first argument must be a fault tree")
 
 	tp<-2
@@ -27,14 +27,24 @@ addLatent<-function(DF, at, mttf, mttr=NULL, pzero="repair", inspect=NULL, tag="
 		stop("connection cannot be made to duplicate nor source of duplication")
 	}
 
+	if(any(DF$Type==5)) {
+		stop("repairable system event event called for in non-repairable model")
+	}
+
+		if(tag!="")  {
+		if (length(which(DF$Tag == tag) != 0)) {
+		stop("tag is not unique")
+		}
+	}
 
 ## There is no need to limit connections to OR gates for calculation reasons
-## Since AND gates are calculated in binary fashion, these too should not require a connection limit
+## Since AND gates are calculated in binary fashion, these too should not
+## require a connection limit, but practicality suggests 3 is a good limit.
 ## All specialty gates must be limited to binary feeds only
 
-##	if(DF$Type[parent]>11 && length(which(DF$Parent==at))>1) {
-##		stop("connection slot not available")
-#3	}
+	if(DF$Type[parent]==11 && length(which(DF$Parent==at))>2) {
+		warning("More than 3 connections to AND gate.")
+	}
 
 	condition=0
 	if(DF$Type[parent]>11 )  {
@@ -81,9 +91,20 @@ addLatent<-function(DF, at, mttf, mttr=NULL, pzero="repair", inspect=NULL, tag="
 		}else{ stop("pzero entry must be zero to one")}
 	}
 
+	gp<-at
+	if(length(display_under)!=0)  {
+		if(DF$Type[parent]!=10) {stop("Component stacking only permitted under OR gate")}
+		if(DF$CParent[display_under]!=at) {stop("Must stack at component under same parent")}
+		if(length(which(DF$GParent==display_under))>0 )  {
+			stop("display under connection not available")
+		}else{
+			gp<-display_under
+		}
+	}
+
 	Dfrow<-data.frame(
 		ID=	thisID	,
-		GParent=	at	,
+		GParent=	gp	,
 		CParent=	at	,
 		Level=	DF$Level[parent]+1	,
 		Type=	tp	,

--- a/R/addProbability.R
+++ b/R/addProbability.R
@@ -14,10 +14,10 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-addProbability<-function(DF, at, prob, tag="", name="", name2="", description="")  {
+addProbability<-function(DF, at, prob, display_under=NULL, tag="", name="", name2="", description="")  {
 	if(!ftree.test(DF)) stop("first argument must be a fault tree")
 
- 	tp=3
+ 	tp=4
 	parent<-which(DF$ID== at)
 	if(length(parent)==0) {stop("connection reference not valid")}
 	thisID<-max(DF$ID)+1
@@ -27,13 +27,21 @@ addProbability<-function(DF, at, prob, tag="", name="", name2="", description=""
 		stop("connection cannot be made to duplicate nor source of duplication")
 	}
 
+if(tag!="")  {
+	if (length(which(DF$Tag == tag) != 0)) {
+	stop("tag is not unique")
+	}
+}
+
 ## There is no need to limit connections to OR gates for calculation reasons
-## Since AND gates are calculated in binary fashion, these too should not require a connection limit
+## Since AND gates are calculated in binary fashion, these too should not
+## require a connection limit, practicality suggests 3 is a good limit.
 ## All specialty gates must be limited to binary feeds only
 
-##	if(DF$Type[parent]>11 && length(which(DF$Parent==at))>1) {
-##		stop("connection slot not available")
-#3	}
+	if(DF$Type[parent]==11 && length(which(DF$Parent==at))>2) {
+		warning("More than 3 connections to AND gate.")
+	}
+
 
 	condition=0
 	if(DF$Type[parent]>11 )  {
@@ -46,13 +54,22 @@ addProbability<-function(DF, at, prob, tag="", name="", name2="", description=""
 		}
 	}
 
-
+	gp<-at
+	if(length(display_under)!=0)  {
+		if(DF$Type[parent]!=10) {stop("Component stacking only permitted under OR gate")}
+		if(DF$CParent[display_under]!=at) {stop("Must stack at component under same parent")}
+		if(length(which(DF$GParent==display_under))>0 )  {
+			stop("display under connection not available")
+		}else{
+			gp<-display_under
+		}
+	}
 
 	if(prob<0 || prob>1)  {stop("probability entry must be between zero and one")}
 
 	Dfrow<-data.frame(
 		ID=	thisID	,
-		GParent=	at	,
+		GParent=	gp	,
 		CParent=	at	,
 		Level=	DF$Level[parent]+1	,
 		Type=	tp	,

--- a/R/ftree.calc.R
+++ b/R/ftree.calc.R
@@ -35,6 +35,9 @@ for(row in dim(sDF)[1]:1)  {
 		Type=sDF$Type[child_rows[1]],
 		PHF=sDF$PHF[child_rows[1]]
 		)
+## Fail rate for exposed type does not pass upward in calculations
+		if(siblingDF$Type[1]==5) {siblingDF$CFR[1]<- (-1) }
+
 	if(length(child_rows)>1)  {
 
 		for(child in 2:length(child_rows))  {
@@ -46,9 +49,10 @@ for(row in dim(sDF)[1]:1)  {
 			Type=sDF$Type[child_rows[child]],
 			PHF=sDF$PHF[child_rows[child]]
 			)
+## Fail rate for exposed type does not pass upward in calculations
+			if(DFrow$Type[1]==5) {DFrow$CFR[1]<- (-1) }
 
-
-		siblingDF<-rbind(siblingDF,DFrow)
+			siblingDF<-rbind(siblingDF,DFrow)
 		}
 	}else{
 		if(sDF$Type[row]>10) {
@@ -88,7 +92,24 @@ for(row in dim(sDF)[1]:1)  {
 		if(siblingDF$PBF[1]<=0)  {
 			stop(paste0("first feed must have prob of failure at gate ", sDF$ID[row]))
 		}
+
+## with this alternative code repairable does not need to be in json
+## cfr print does not have to be suppressed on conditional
+## eliminate fail rate (cfr) values (set to -1) for the conditional feed to advanced gates
+		sDF$CFR[which(sDF$ID==siblingDF$ID[1])]<- (-1)
+## eliminate repair time (crt) values (set to -1) for the conditional feed EXCEPT repairable condition
+		if (sDF$Repairable[row] == 0) {
+			sDF$CRT[which(sDF$ID==siblingDF$ID[1])]<- (-1)
+		}
+
 	}
+
+## Using this code repairable flag must be sent via json
+## condition flag is used to suppress fail rate display
+## Set the repairable flag on the feeding condition if applicable
+##		if (sDF$Repairable[row] == 1) {
+##			sDF$Repairable[which(sDF$ID==siblingDF$ID[1])]<-1
+##		}
 
 	## INHIBIT gate calculation
 	if(sDF$Type[row]==12)  {

--- a/R/ftree2html.R
+++ b/R/ftree2html.R
@@ -1,26 +1,28 @@
-ftree2html<-function(DF,dir="", write_file=FALSE){			
-	if(!ftree.test(DF)) stop("first argument must be a fault tree")		
-			
-	html_string<-paste0(		
+ftree2html<-function(DF,dir="", write_file=FALSE){
+	if(!ftree.test(DF)) stop("first argument must be a fault tree")
+
+	html_string<-paste0(
 		HTMLhead,
 		##ftree2json(DF,c(1,2,4:7,15,17,18))	,
 		##hierarchyDF2json(DF,id.col=1,parent.col=3,data.col=c(1,2,4:7,15,17,18)),
-		hierarchyDF2json(DF,data.col=c(1,5:16)),
-		HTMLd3script	
-	)		 
-			
-			
-	if(write_file==TRUE)  {				
-		DFname<-paste(deparse(substitute(DF)))			
-					
-		file_name<-paste0(dir,DFname,".html")			
-					
-		eval(parse(text=paste0('write(html_string,"',file_name,'")')))			
-					
-	}		
-						
-DF[,1:7]		
-}			
+##		hierarchyDF2json(DF,data.col=c(1,5:16)),
+## eliminating repairable data attribute will result in:
+		hierarchyDF2json(DF,data.col=c(1,5:11,13:16)),
+		HTMLd3script
+	)
+
+
+	if(write_file==TRUE)  {
+		DFname<-paste(deparse(substitute(DF)))
+
+		file_name<-paste0(dir,DFname,".html")
+
+		eval(parse(text=paste0('write(html_string,"',file_name,'")')))
+
+	}
+
+DF[,1:7]
+}
 
 ############################ HTML strings #####################################
 
@@ -45,17 +47,16 @@ var tree = d3.layout.tree()
 .nodeSize([rectW*1.15, rectH*1.2])
 .separation(function(a, b) { return (a.parent == b.parent ? 1 : 1.2); });
 var svg = d3.select("#body").append("svg").attr("width", 1000).attr("height", 1000)
-.call(zm = d3.behavior.zoom().scaleExtent([1,3]).on("zoom", redraw)).append("g")
+.call(zm = d3.behavior.zoom().scaleExtent([.5,3]).on("zoom", redraw)).append("g")
 .attr("transform", "translate(" + 350 + "," + 20 + ")");
 zm.translate([350, 20]);
 root.x0 = 0;
 root.y0 = height / 2;
 function collapse(d) {
 if (d.children) {
-d._children = d.children; 
+d._children = d.children;
 d._children.forEach(collapse);
 d.children = null;}}
-root.children.forEach(collapse);
 update(root);
 d3.select("#body").style("height", "800px");
 function update(source) {
@@ -97,7 +98,7 @@ var inhibitGate="m 60,35 -15,6.340 0,17.3205 15,6.340  15,-6.340 0,-17.3205 z";
 var alarmGate="m 75,65 c  -1.4, -10, .6, -22 -15, -30 -15.6, 8, -13.4, 20, -15, 30, 0, 0 3, -8 15, -8 10, 0 15, 8 15, 8 z m -30,0 v5 c0, 0 3, -8 15, -8 10, 0 15, 8 15, 8 v-5";
 var component="m 75, 50 a15,15 .2 0,0 -15,-15 a15,15 .2 0,0 -15,15 a15,15 .2 0,0 15,15 a15,15 .2 0,0 15,-15";
 nodeEnter.append("path")
-.attr("d",  
+.attr("d",
 function(d) {switch (d.type) {
 case 10 : return(orGate);
 break;
@@ -112,34 +113,57 @@ break;
 default : return(component);
 }})
 .attr({stroke:"black",
-"stroke-width":1.5, 
-"stroke-linejoin":"round", 
+"stroke-width":1.5,
+"stroke-linejoin":"round",
 fill: "#fff"});
 nodeEnter.append("text")
 .attr("x", rectW / 2-2)
 .attr("y", TrectH  + 25)
 .attr("text-anchor", "middle")
-.attr("fill", "red")
+.attr("fill",  function(d){return d.moe==0 ? "red": "magenta";})
 .text(function (d) {
-return d.id;});
+return d.moe>0 ? d.moe : d.id ;});
+nodeEnter.append("text")
+.attr("x", rectW / 2 -56)
+.attr("y", TrectH  -26)
+.attr("text-anchor", "middle")
+.attr("fill", "magenta")
+.text(function (d) {
+return d.moe > 0 ? "R" : d.moe<0 ? "S" : "" ;});
+nodeEnter.append("text")
+.attr("x", rectW / 2 -28)
+.attr("y", TrectH  -26)
+.attr("text-anchor", "right")
+.attr("fill", "navy")
+.text(function (d) {
+return d.condition > 0 ? "Cond" : "" ;});
+nodeEnter.append("text")
+.attr("x", rectW / 2 +44)
+.attr("y", TrectH  -26)
+.attr("text-anchor", "right")
+.attr("fill",  function(d){return d.moe==0 ? "red": "magenta";})
+.text(function (d) {
+return d.tag_obj;});
 nodeEnter.append("text")
 .attr("x", rectW/2+18)
 .attr("y", TrectH  + 12)
 .attr("text-anchor", "left")
 .attr("fill", "green")
+//.text(function (d) { return d.cfr>0&&d.condition==0 ? "Fail Rate":"";});
 .text(function (d) { return d.cfr>0 ? "Fail Rate":"";});
 nodeEnter.append("text")
 .attr("x", rectW/2+18)
 .attr("y", TrectH  + 24)
 .attr("text-anchor", "left")
 .attr("fill", "green")
+//.text(function (d) {return d.cfr>0&&d.condition==0 ? (d.cfr).toExponential(4):"";});
 .text(function (d) {return d.cfr>0 ? (d.cfr).toExponential(4):"";});
 nodeEnter.append("text")
 .attr("x", rectW/2+18)
 .attr("y", TrectH  + 36)
 .attr("text-anchor", "left")
 .attr("fill", "navy")
-.text(function (d) { return d.pbf>0 ? "Prob":"";});     
+.text(function (d) { return d.pbf>0 ? "Prob":"";});
 nodeEnter.append("text")
 .attr("x", rectW/2+18)
 .attr("y", TrectH  + 48)
@@ -147,35 +171,35 @@ nodeEnter.append("text")
 .attr("fill", "navy")
 .text(function (d) {return d.pbf>0 ? (d.pbf).toExponential(4):"" ;});
 nodeEnter.append("text")
-.attr("x", -3)
+.attr("x", -4)
 .attr("y", TrectH  + 12)
 .attr("text-anchor", "left")
-.attr("fill", "black")
-.text(function (d) { return d.type==13 ? "Human":"";});
+//.attr("fill",  function(d){return d.condition==0 ? "lightgray": d.repairable==1 ? "dimgray": "white" ;})
+.attr("fill",  function(d){return d.condition==1 ? "dimgray":"lightgray" ;})
+.text(function (d) { return d.crt>0 ? "Repair Time":"";});
 nodeEnter.append("text")
-.attr("x", -3)
+.attr("x", -4)
 .attr("y", TrectH  + 24)
 .attr("text-anchor", "left")
-.attr("fill", "black")
-.text(function (d) { return d.type==13 ? "Response":"";});
+//.attr("fill",  function(d){return d.condition==0 ? "lightgray": d.repairable==1 ? "dimgray": "white" ;})
+.attr("fill",  function(d){return d.condition==1 ? "dimgray":"lightgray" ;})
+.text(function (d) {return d.crt>0 ? (d.crt).toExponential(4):"" ;});
 nodeEnter.append("text")
-.attr("x", -3)
-.attr("y", TrectH  + 36)
-.attr("text-anchor", "left")
-.attr("fill", "black")
-.text(function (d) { return d.type==13 ? "Failure":"";});
-nodeEnter.append("text")
-.attr("x", -3)
+.attr("x", -4)
 .attr("y", TrectH  + 48)
 .attr("text-anchor", "left")
 .attr("fill", "black")
-.text(function (d) { return d.type==13 ? "Ph="+parseFloat(d.phf_pz.toFixed(2)) :"";});  
+.text(function (d) { return d.type==13 ? "Phf="+parseFloat(d.phf_pz.toFixed(2)) :"";});
 nodeEnter.append("text")
-.attr("x", rectW/2)
+//.attr("x", rectW/2)
+.attr("x", function(d) { return d.type==2 ? rectW/2 : rectW/2+10;})
 .attr("y", TrectH  + 60)
-.attr("text-anchor", "middle")
+.attr("text-anchor", function(d) { return d.type==2 ? "middle" : "left";})
 .attr("fill", "maroon")
-.text(function (d) { return d.type==2 ? "T="+parseFloat(d.interval.toFixed(4)) +" Po=" +parseFloat(d.phf_pz.toFixed(5)) :"";});             
+.text(function (d) {
+	return d.type==2 ? "T="+parseFloat(d.interval.toFixed(4)) +" Po=" +parseFloat(d.phf_pz.toFixed(5))
+	: d.type==5 ? "T="+parseFloat(d.interval.toFixed(4))
+	:"";});
 var nodeUpdate = node.transition()
 .duration(duration)
 .attr("transform", function (d) {

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ tree2[,1:7]
 
 
 ftree2html(tree2, write_file=TRUE)
+
 browseURL('tree2.html')
 
 ## example 3  **************** Minimal Cut Set Generation   ***************

--- a/man/addActive.rd
+++ b/man/addActive.rd
@@ -6,8 +6,8 @@
 \description{Modifies an existing fault tree with the addition of an active component event.}
 
 \usage{
-addActive(DF, at, mttf=NULL, mttr=NULL, tag="", name="",name2="",
- description="")
+addActive(DF, at, mttf=NULL, mttr=NULL, display_under=NULL, tag="", 
+ name="",name2="",description="")
 }
 
 \arguments{
@@ -15,6 +15,7 @@ addActive(DF, at, mttf=NULL, mttr=NULL, tag="", name="",name2="",
 \item{at}{ The ID of the parent node for this addition.}
 \item{mttf}{The mean time to failure.  It is the user's responsibility to maintain constant units of time.}
 \item{mttr}{The mean time to repair (restore).  It is the user's responsibility to maintain constant units of time.}
+\item{display_under}{Optionally, the ID of a sibling event under an OR gate for vertical alignment of the component node in the graphic display.}
 \item{tag}{ A very short identifying string (typically 5 characters or less) uniquely identifying a basic event for minimal cutset evaluation}
 \item{name}{ A short identifying string  (typically less than 24 characters)}
 \item{name2}{ A second line, if needed for the identifying string label}

--- a/man/addExposed.rd
+++ b/man/addExposed.rd
@@ -1,19 +1,23 @@
-\name{addProbability}
-\alias{addProbability}
+\name{addExposed}
+\alias{addExposed}
 
 \title{ Add a Pure Probability }
 
-\description{Modifies an existing fault tree with the addition of a pure probability.}
+\description{Adds a basic component event to a fault tree in which probability of failure 
+ is defined by fail rate and exposure time.}
 
 \usage{
-addProbability(DF, at, prob, display_under=NULL, tag="",  
-	name="", name2="", description="")
+addExposed(DF, at, mttf, exposure=NULL, dist="exponential", p2=NULL,
+		display_under=NULL, tag="", name="",name2="", description="")
 }
 
 \arguments{
 \item{DF}{ A fault tree dataframe such as returned from ftree.make or related add... functions.}
 \item{at}{ The ID of the parent node for this addition.}
-\item{prob}{A probability value >0 && <1}
+\item{mttf}{The mean time to failure.  It is the user's responsibility to maintain constant units of time.}
+\item{exposure}{The mission time over which a system is exposed to failure.}
+\item{dist}{The probabilty distribution to be used for defining probability of failure from mttf, and a possible extra parameter. Default is "exponential", expected implementation of "weibull" to follow.}
+\item{p2}{A placeholder for a second parameter for 2-parameter failure distribution, such as "weibull". Not yet implemented.}
 \item{display_under}{Optionally, the ID of a sibling event under an OR gate for vertical alignment of the component node in the graphic display.}
 \item{tag}{ A very short identifying string (typically 5 characters or less) uniquely identifying a basic event for minimal cutset evaluation}
 \item{name}{ A short identifying string  (typically less than 24 characters)}
@@ -22,10 +26,12 @@ addProbability(DF, at, prob, display_under=NULL, tag="",
 }
 
 \value{
-Returns the input fault tree dataframe appended with an entry row for the defined probability.
+Returns the input fault tree dataframe appended with an entry row for the defined failure event.
 }
 
 \references{
+  Ericson, Clifton A. II (2011) Fault Tree Analysis Primer  CreateSpace Inc.
+  
   Nicholls, David [Editor] (2005) System Reliability Toolkit  Reliability information Analysis 
   Center
   
@@ -38,13 +44,13 @@ Returns the input fault tree dataframe appended with an entry row for the define
   Fault Tree Handbook with Aerospace Applications   NASA
   
   Doelp, L.C., Lee, G.K., Linney, R.E., Ormsby R.W. (1984) Quantitative fault tree analysis: Gate-by-gate method Plant/Operations Progress
-Volume 3, Issue 4 American Institute of Chemical Engineers
+  Volume 3, Issue 4 American Institute of Chemical Engineers
 }
 
 \examples{
-mytree <-ftree.make(type="and", name="common cause failure", name2="of redundant pumps")
-mytree<-addActive(mytree,at=1,mttf=3,mttr=12/8760, name="Pump")
-mytree <- addProbability(mytree,  at=1, prob=.05, name="common cause", name2="beta factor")
+mytree <-ftree.make(type="or", name="6-month task", name2="incomplete")
+mytree <- addExposed(mytree,  at=1, mttf=3, exposure=0.5, name="pump fails",
+   name2="before completion")
 }
 
 \keyword{ logic, risk, failure }

--- a/man/addLatent.rd
+++ b/man/addLatent.rd
@@ -7,7 +7,7 @@
 
 \usage{
 addLatent(DF, at, mttf, mttr=NULL, pzero="repair", inspect=NULL, 
-		tag="", name="", name2="", description="")
+		display_under=NULL, tag="", name="", name2="", description="")
 }
 
 \arguments{
@@ -17,6 +17,7 @@ addLatent(DF, at, mttf, mttr=NULL, pzero="repair", inspect=NULL,
 \item{mttr}{The mean time to repair (restore).  It is the user's responsibility to maintain constant units of time.}
 \item{pzero}{An underlying probability of the component being in a failed state. This will be additive to the fractional downtime due to inspection interval. A probability value >=0 && <1 can be provided. Often it is known that unavailable risk continues during repair upon inspection detection, so a string value of "repair" is accepted and the Pzero will be calculated as mttr/(mttf/mttr).}
 \item{inspect}{The time interval between inspections for the dormant component. (It will be possible upon future development to enter the string for the named inspection dataframe object.  In this case the inspection object will be read to get the inspection interval. An inspection object must be a dataframe with interval and duration columns. If a positive duration value other than zero is found it is taken that the system is at risk during the time of inspection. An unavailable probability calculated as duration/(interval+duration) will be added to the fractional downtime.}
+\item{display_under}{Optionally, the ID of a sibling event under an OR gate for vertical alignment of the component node in the graphic display.}
 \item{tag}{ A very short identifying string (typically 5 characters or less) uniquely identifying a basic event for minimal cutset evaluation}
 \item{name}{ A short identifying string  (typically less than 24 characters)}
 \item{name2}{ A second line, if needed for the identifying string label}

--- a/man/ftree-package.Rd
+++ b/man/ftree-package.Rd
@@ -24,6 +24,8 @@ Jacob T. Ormerod
 Maintainer: Jacob T. Ormerod <jake@openreliability.org>
 }
 \references{
+  Ericson, Clifton A. II (2011) Fault Tree Analysis Primer  CreateSpace Inc.
+  
   Nicholls, David [Editor] (2005) System Reliability Toolkit  Reliability information Analysis 
   Center
   


### PR DESCRIPTION
Added Repair Time display in place of Alarm gate text
eliminate repair time or fail rate display when not applicable
Condition feed indication
Duplicate node indication
tag arguments and display for basic elements
displaly_under args for vertical display of basic elements under OR
gates
Defined an Exposed basic element provided for its entry and control of
erroneous use.
